### PR TITLE
update environment.yml to remove pip-by-urls

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,4 @@ dependencies:
 - pytest
 - pip
 - pip:
-  - git+https://github.com/iobis/pyxylookup.git#egg=pyxylookup
-  - git+https://github.com/iobis/obis-qc.git#egg=obisqc
-  - git+https://github.com/pieterprovoost/isodateparser.git#egg=isodateparser
+  pyxylookup

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - pytest
 - pip
 - pip:
-  pyxylookup
+  - pyxylookup


### PR DESCRIPTION
Attempting to remove some of the weird dependencies now that pyxylookup is published in PyPI. Will hopefully be able to remove obis-qc and isodateparser as direct dependencies.